### PR TITLE
Add Input to Handle dotnet-ef version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This action is responsible for applying .NET migrations to a database
 
 **Required**: The startup project of the application
 
+### `dotnet-ef-version`
+
+**Not Required**: The version of the `dotnet-ef` global tool to be installed. By default, it is empty and it will install the latest version.
+
 ### `context`
 
 **Required**: The DbContext class name
@@ -28,6 +32,7 @@ This action is responsible for applying .NET migrations to a database
   with:
     project-path: ./src/FooProject
     startup-project-path: ./src/FooProject.API
+    dotnet-ef-version
     context: FooDbContext
     connection: <CONNECTION_STRING_GOES_HERE>
 ```

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   startup-project-path:
     description: "The startup project of the application"
     required: true
+  dotnet-ef-version:
+    description: "The version of dotnet-ef tool"
+    required: false
+    default: ""
   context:
     description: "The DbContext class name"
     required: true
@@ -25,8 +29,16 @@ runs:
       run: dotnet tool uninstall --global dotnet-ef || true
 
     - name: Install dotnet ef tool
+      if: ${{ inputs.dotnet-ef-version == '' }}
       shell: bash
       run: dotnet tool install --global dotnet-ef
+
+    - name: Install dotnet ef tool
+      if: ${{ inputs.dotnet-ef-version != '' }}
+      shell: bash
+      env:
+        VERSION: ${{ inputs.dotnet-ef-version }}
+      run: dotnet tool install --global dotnet-ef --version $VERSION
 
     - name: Update database
       shell: bash


### PR DESCRIPTION
# V3

Adding `dotnet-ef-version` input to allow consumers to define the version of the global tool to be installed.